### PR TITLE
Add PlayerAchievement model and leaderboard

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,9 @@
 import express from 'express';
 import mongoose from 'mongoose';
 
+import { Player, PlayerAchievement, Game, GameAchievement } from './models/index.js';
+import calculatePoints from './utils/calculatePoints.js';
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 const MONGO_URL = process.env.MONGO_URL || "mongodb://mongo:27017/factum";
@@ -11,6 +14,39 @@ app.use(express.json());
 // Simple ruta test
 app.get('/', (req, res) => {
   res.send('Factum Backend is running!');
+});
+
+// Leaderboard endpoint
+app.get('/leaderboard', async (req, res) => {
+  try {
+    const achievements = await PlayerAchievement.find()
+      .populate('player')
+      .populate('game')
+      .populate('achievement');
+
+    const scores = {};
+
+    achievements.forEach(a => {
+      const percent = a.achievement?.percent || 0;
+      const playtime = a.game?.playtime_forever || 0;
+      const points = a.points ?? calculatePoints(percent, playtime, a.unlocktime);
+      const pid = a.player.id;
+      if (!scores[pid]) {
+        scores[pid] = {
+          steamid: a.player.steamid,
+          personaname: a.player.personaname,
+          totalPoints: 0
+        };
+      }
+      scores[pid].totalPoints += points;
+    });
+
+    const leaderboard = Object.values(scores).sort((a, b) => b.totalPoints - a.totalPoints);
+    res.json(leaderboard);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to generate leaderboard' });
+  }
 });
 
 // Conexión a MongoDB

--- a/backend/src/models/PlayerAchievement.js
+++ b/backend/src/models/PlayerAchievement.js
@@ -1,0 +1,13 @@
+import { Schema, model, Types } from 'mongoose';
+
+const playerAchievementSchema = new Schema({
+  player: { type: Types.ObjectId, ref: 'Player', required: true },
+  achievement: { type: Types.ObjectId, ref: 'GameAchievement', required: true },
+  game: { type: Types.ObjectId, ref: 'Game', required: true },
+  unlocktime: Number,
+  points: Number,
+});
+
+playerAchievementSchema.index({ player: 1, achievement: 1 }, { unique: true });
+
+export default model('PlayerAchievement', playerAchievementSchema);

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -5,3 +5,4 @@ export { default as Friend } from './Friend.js';
 export { default as Achievement } from './Achievement.js';
 export { default as GameAchievement } from './GameAchievement.js';
 export { default as GameDetail } from './GameDetail.js';
+export { default as PlayerAchievement } from './PlayerAchievement.js';

--- a/backend/src/utils/calculatePoints.js
+++ b/backend/src/utils/calculatePoints.js
@@ -1,0 +1,8 @@
+export default function calculatePoints(percent = 0, playtime = 0, unlocktime = 0) {
+  const rarity = 1 - percent / 100;
+  const playtimeHours = playtime / 60; // convert minutes to hours
+  const daysSinceUnlock = ((Date.now() / 1000) - unlocktime) / 86400;
+  const recency = 1 / (daysSinceUnlock + 1);
+  const score = rarity * 70 + playtimeHours * 20 + recency * 10;
+  return Math.round(score * 100) / 100;
+}


### PR DESCRIPTION
## Summary
- add `PlayerAchievement` schema with `points`
- add points algorithm utility
- create `/leaderboard` endpoint that ranks players by total points

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688764fc4e008328b7c5fa77963d6eba