### PR TITLE
Add Steam API key configuration

### DIFF
--- a/Docker-compose.yml
+++ b/Docker-compose.yml
@@ -29,6 +29,7 @@ services:
     environment:
       - PORT=3000
       - MONGO_URL=mongodb://mongo:27017/factum
+      - STEAM_API_KEY=${STEAM_API_KEY}
     depends_on:
       - mongo
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,17 @@ factum/
 git clone https://github.com/SrGalletaEXT/factum.git
 cd factum
 ```
-### **3. Levanta todos los servicios con Docker Compose**
+### 3. **Configura `STEAM_API_KEY`**
+
+Crea un archivo `.env` en la raíz del proyecto con tu clave:
+
+```bash
+STEAM_API_KEY=tu_clave_de_steam
+```
+
+También puedes editar `docker-compose.yml` y colocar el valor directamente en el servicio `backend`.
+
+### **4. Levanta todos los servicios con Docker Compose**
 ```bash
 docker-compose up --build -d
 ```
@@ -52,7 +62,7 @@ Backend (http://localhost:3000)
 
 Frontend (http://localhost:4200)
 
-### **4. Accede a los servicios**
+### **5. Accede a los servicios**
 
 Frontend Angular: http://localhost:4200
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4,6 +4,7 @@ import mongoose from 'mongoose';
 const app = express();
 const PORT = process.env.PORT || 3000;
 const MONGO_URL = process.env.MONGO_URL || "mongodb://mongo:27017/factum";
+const STEAM_API_KEY = process.env.STEAM_API_KEY || '';
 
 // Middleware
 app.use(express.json());


### PR DESCRIPTION
## Summary
- expose `STEAM_API_KEY` in `docker-compose.yml`
- read `STEAM_API_KEY` from environment in backend
- document how to configure the key via `.env` or Docker Compose

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688764da995c8328b4686603abe9c4f6